### PR TITLE
주간 예산 등록 기능 추가 & 홈 디자인 QA

### DIFF
--- a/lib/bind/weeklyBudgets/weekly_budgets.dart
+++ b/lib/bind/weeklyBudgets/weekly_budgets.dart
@@ -1,0 +1,14 @@
+import 'package:get/get.dart';
+import 'package:poorlex/controller/weekly_budgets.dart';
+
+class WeeklyBudgetsBind extends Bindings {
+  @override
+  void dependencies() {
+    Get.put(
+      WeeklyBudgetsController(
+        weeklyBudgetsProvider: Get.find(),
+      ),
+      permanent: true,
+    );
+  }
+}

--- a/lib/controller/weekly_budgets.dart
+++ b/lib/controller/weekly_budgets.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:poorlex/models/weeklyBudget.dart';
 import 'package:poorlex/provider/weekly_budgets_provider.dart';
 import 'package:poorlex/schema/weekly_budget_left_response/weekly_budget_left_response.dart';
 import 'package:poorlex/schema/weekly_budget_response/weekly_budget_response.dart';
@@ -9,6 +10,9 @@ class WeeklyBudgetsController extends GetxController {
   WeeklyBudgetsController({
     required this.weeklyBudgetsProvider,
   });
+
+  final _createWeeklyBudgets = WeeklyBudgetCreateModel().obs;
+  WeeklyBudgetCreateModel get createWeeklyBudget => _createWeeklyBudgets.value;
 
   final Rx<WeeklyBudgetResponse> weeklyBudget = WeeklyBudgetResponse(
     exist: false,
@@ -21,6 +25,16 @@ class WeeklyBudgetsController extends GetxController {
     exist: false,
     amount: 0,
   ).obs;
+
+  void initCreateWeeklyBudget() {
+    _createWeeklyBudgets(WeeklyBudgetCreateModel());
+  }
+
+  void changeBudget(int budget) {
+    _createWeeklyBudgets.update((val) {
+      val?.budget = budget;
+    });
+  }
 
   /// 요청 날짜 포함 주간 예산 조회
   Future<void> getWeeklyBudgets() async {
@@ -43,15 +57,17 @@ class WeeklyBudgetsController extends GetxController {
   }
 
   /// 주간 예산 생성
-  Future<void> postCreateWeeklyBudgets({
+  Future<bool> postCreateWeeklyBudgets({
     required int budget,
   }) async {
     try {
-      await weeklyBudgetsProvider.postCreateWeeklyBudgets(
+      final result = await weeklyBudgetsProvider.postCreateWeeklyBudgets(
         budget: budget,
       );
+      return result;
     } catch (e) {
       print(e);
+      return false;
     }
   }
 }

--- a/lib/libs/theme.dart
+++ b/lib/libs/theme.dart
@@ -22,6 +22,7 @@ class CColors {
   /// figma greyScale90 > 10으로 쓰고있음 확인필요
   static final Color gray10 = Color(0xFF1A1A1A);
   static final Color black = Color(0xFF0A0A0A);
+  static final Color blackOpa80 = Color(0xFF1E1E1E);
 
   static final Color brownLight = Color(0xFFE4D4BE);
   static final Color brown = Color(0xFFB59767);

--- a/lib/models/weeklyBudget.dart
+++ b/lib/models/weeklyBudget.dart
@@ -1,0 +1,7 @@
+class WeeklyBudgetCreateModel {
+  late int budget;
+
+  WeeklyBudgetCreateModel({
+    this.budget = 0,
+  });
+}

--- a/lib/provider/weekly_budgets_provider.dart
+++ b/lib/provider/weekly_budgets_provider.dart
@@ -37,10 +37,16 @@ class WeeklyBudgetsProvider extends GetConnect {
   }
 
   /// 주간 예산 생성
-  Future<void> postCreateWeeklyBudgets({
+  Future<bool> postCreateWeeklyBudgets({
     required int budget,
   }) async {
-    final response = await post("", {'budget': budget});
-    print("주간 예산 생성 > $response");
+    try {
+      final response = await post("", {'budget': budget});
+      print("주간 예산 생성 > $response");
+      return response.status == 201;
+    } catch (e) {
+      print(e);
+      return false;
+    }
   }
 }

--- a/lib/screen/battle/battle.dart
+++ b/lib/screen/battle/battle.dart
@@ -56,8 +56,10 @@ class _BattleState extends State<Battle> {
         beggarAction: BeggarAction.suggestionBudget,
       );
 
-      if (result == true) {
+      if (result == false) {
         /// [TODO] 예산 설정하러 가기 라우팅
+        print('예산 설정하러 가기');
+        Get.toNamed('/budget');
       }
     });
 

--- a/lib/screen/home/home.dart
+++ b/lib/screen/home/home.dart
@@ -1,10 +1,10 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:poorlex/controller/firbase_controller.dart';
+import 'package:poorlex/controller/battle.dart';
+// import 'package:poorlex/controller/firbase_controller.dart';
 import 'package:poorlex/controller/weekly_budgets.dart';
 import 'package:poorlex/libs/theme.dart';
+import 'package:poorlex/schema/member_progress_battle_response/member_progress_battle_response.dart';
 
 import 'package:poorlex/widget/home/home_nav_bar.dart';
 import 'package:poorlex/widget/home/carousel_slider.dart';
@@ -38,6 +38,7 @@ class _MainState extends State<Main> {
   // }
 
   late final _budget = Get.find<WeeklyBudgetsController>();
+  BattleController battle = Get.find<BattleController>();
 
   @override
   void initState() {
@@ -48,6 +49,8 @@ class _MainState extends State<Main> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _budget.getWeeklyBudgets();
     });
+
+    battle.getBattleInProgress();
 
     /// [MEMO] 1차 배포에 포함안하기 때문에 주석처리
     /// 해당 부분 modal 새로 구현해야합니다.
@@ -62,10 +65,14 @@ class _MainState extends State<Main> {
   Widget build(BuildContext context) {
     final double deviceWidth = MediaQuery.of(context).size.width;
     final double deviceHeight = MediaQuery.of(context).size.height;
+    final List<MemberProgressBattleResponse> battleListInProgress =
+        battle.battleListInProgress;
 
     return Obx(
       () {
         final budget = _budget.weeklyBudget.value;
+
+        print('#Home# budget: ${budget}');
 
         return Scaffold(
           // 네비게이션 바
@@ -91,7 +98,8 @@ class _MainState extends State<Main> {
                     decoration: BoxDecoration(
                       image: DecorationImage(
                         image: AssetImage('assets/main_page/background_1.png'),
-                        fit: BoxFit.cover,
+                        fit: BoxFit.contain,
+                        repeat: ImageRepeat.repeatX,
                         alignment: Alignment.bottomCenter,
                       ),
                     ),
@@ -125,7 +133,8 @@ class _MainState extends State<Main> {
                     decoration: BoxDecoration(
                       image: DecorationImage(
                         image: AssetImage('assets/main_page/background_2.png'),
-                        fit: BoxFit.cover,
+                        fit: BoxFit.contain,
+                        repeat: ImageRepeat.repeatX,
                         alignment: Alignment.bottomCenter,
                       ),
                     ),
@@ -133,7 +142,7 @@ class _MainState extends State<Main> {
                 ),
 
                 // 예산 설정 안내 문구
-                if (budget.amount == 0)
+                if (budget.exist == false)
                   Positioned(
                     top: 4,
                     left: 15,
@@ -192,14 +201,17 @@ class _MainState extends State<Main> {
                                 child: Column(
                                   mainAxisAlignment: MainAxisAlignment.end,
                                   children: [
-                                    MainCarouselSlider(),
+                                    MainCarouselSlider(
+                                        battleListInProgress:
+                                            battleListInProgress),
                                   ],
                                 ),
                               )
                             : Column(
-                                mainAxisAlignment: MainAxisAlignment.end,
                                 children: [
-                                  MainCarouselSlider(),
+                                  MainCarouselSlider(
+                                      battleListInProgress:
+                                          battleListInProgress),
                                 ],
                               ),
                       );
@@ -218,6 +230,7 @@ class _MainState extends State<Main> {
   }
 }
 
+// 예산 설정 안내 문구 말풍선 삼각형
 class TriangleClipper extends CustomClipper<Path> {
   @override
   Path getClip(Size size) {

--- a/lib/widget/common/bottom_bar.dart
+++ b/lib/widget/common/bottom_bar.dart
@@ -88,7 +88,7 @@ class _BottomBarState extends State<BottomBar> {
           return BottomNavigationBarItem(
             label: item.value.label,
             icon: Padding(
-              padding: EdgeInsets.all(6),
+              padding: EdgeInsets.only(bottom: 6),
               child: Column(
                 children: [
                   if (widget.nowPage == item.key) ...[

--- a/lib/widget/common/dialog/common_alert.dart
+++ b/lib/widget/common/dialog/common_alert.dart
@@ -43,7 +43,7 @@ Future<void> commonAlert({
                         type: ButtonTypes.elevated,
                         color: CColors.yellow,
                         child: Text(
-                          "입력하기",
+                          buttonText != null ? buttonText : "입력하기",
                           style: CTextStyles.Headline(color: CColors.gray10),
                         ),
                       ),

--- a/lib/widget/common/money_bar/money_bar.dart
+++ b/lib/widget/common/money_bar/money_bar.dart
@@ -7,10 +7,10 @@ class MoneyBar extends StatelessWidget {
   ///  15 ~20
   static final Color lightGoldText = Color.fromRGBO(63, 48, 0, 1);
 
-  ///  8 ~ 14
+  ///  9 ~ 14
   static final Color silverText = Color.fromRGBO(54, 54, 54, 1);
 
-  ///  1 ~ 7
+  ///  1 ~ 8
   static final Color goldText = Color.fromRGBO(115, 41, 0, 1);
 
   final int money;
@@ -27,52 +27,106 @@ class MoneyBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final moneyToString = (money / 10000).toStringAsFixed(0);
     return Container(
-      decoration: BoxDecoration(
-        image: DecorationImage(
-          image: AssetImage(
-            _getAssetImageName(money),
-          ),
-          fit: BoxFit.cover,
-        ),
-        borderRadius: BorderRadius.circular(4),
-      ),
       width: width,
       height: height,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Text(
-            moneyToString,
-            style: CTextStyles.Headline(
-              color: _getTextColor(money),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(
+          color: _getBorderColor(money),
+          width: 2,
+        ),
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: _getBackgroundColor(money),
+          borderRadius: BorderRadius.circular(2),
+          border: Border(
+            top: BorderSide(
+              color: _getInnerBorderColor(money),
+              width: 2,
             ),
           ),
-          Text(
-            '만원',
-            style: CTextStyles.Caption2(
-              color: _getTextColor(money),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              moneyToString,
+              style: width > 40
+                  ? TextStyle(
+                      fontSize: 28,
+                      color: _getTextColor(money),
+                      height: 1.0,
+                      wordSpacing: -0.25,
+                    )
+                  : CTextStyles.Headline(
+                      color: _getTextColor(money),
+                    ),
             ),
-          )
-        ],
+            Text(
+              '만원',
+              style: width > 40
+                  ? CTextStyles.Body3(
+                      color: _getTextColor(money),
+                    )
+                  : CTextStyles.Caption2(
+                      color: _getTextColor(money),
+                    ),
+            )
+          ],
+        ),
       ),
     );
   }
 
-  String _getAssetImageName(int money) {
+  Color _getBackgroundColor(int money) {
     switch (money) {
-      case <= 70000:
-        return "assets/money_bar/gold_bg.png";
+      case <= 80000:
+        return Color(0xFFFFD80C);
       case <= 140000:
-        return "assets/money_bar/silver_bg.png";
+        return Color(0xFFCACACA);
       default:
-        return "assets/money_bar/light_gold_bg.png";
+        return Color(0xFFD7C53B);
     }
   }
 
+  Color _getBorderColor(int money) {
+    switch (money) {
+      case <= 80000:
+        return Color(0xFFD07309);
+      case <= 140000:
+        return Color(0xFF9D9995);
+      default:
+        return Color(0xFF8F6E00);
+    }
+  }
+
+  Color _getInnerBorderColor(int money) {
+    switch (money) {
+      case <= 80000:
+        return Color(0xFFFEFF73);
+      case <= 140000:
+        return Color(0xFFFCFCFC);
+      default:
+        return Color(0xFFFEFF73);
+    }
+  }
+
+  // String _getAssetImageName(int money) {
+  //   switch (money) {
+  //     case <= 80000:
+  //       return "assets/money_bar/gold_bg.png";
+  //     case <= 140000:
+  //       return "assets/money_bar/silver_bg.png";
+  //     default:
+  //       return "assets/money_bar/light_gold_bg.png";
+  //   }
+  // }
+
   Color _getTextColor(int money) {
     switch (money) {
-      case <= 70000:
+      case <= 80000:
         return goldText;
       case <= 140000:
         return silverText;

--- a/lib/widget/home/battle_box.dart
+++ b/lib/widget/home/battle_box.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 
 import 'package:poorlex/libs/theme.dart';
+import 'package:poorlex/schema/member_progress_battle_response/member_progress_battle_response.dart';
+import 'package:poorlex/widget/common/money_bar/money_bar.dart';
 
 class BattleBox extends StatelessWidget {
-  final List<String> sample;
+  final MemberProgressBattleResponse battle;
   const BattleBox({
     super.key,
-    required this.sample,
+    required this.battle,
   });
 
   @override
   Widget build(BuildContext context) {
+    // print('battle: $battle');
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
@@ -42,56 +45,26 @@ class BattleBox extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: [
                             // 금액 메달
-                            Container(
+                            MoneyBar(
+                              money: battle.budgetLeft,
                               width: 48,
                               height: 56,
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(4),
-                                border: Border.all(
-                                  color: const Color(0xFF8F6E00),
-                                  width: 2,
-                                ),
-                              ),
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: const Color(0xFFD7C53B),
-                                  borderRadius: BorderRadius.circular(2),
-                                  border: Border(
-                                    top: BorderSide(
-                                      color: const Color(0xFFFEFF73),
-                                      width: 2,
-                                    ),
-                                  ),
-                                ),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Text(sample[0],
-                                        style: CTextStyles.LargeTitle(
-                                            color: CColors.black)),
-                                    Text(
-                                      '만원',
-                                      style: CTextStyles.Body3(
-                                        color: CColors.black,
-                                      ),
-                                    )
-                                  ],
-                                ),
-                              ),
                             ),
 
                             SizedBox(width: 18),
 
-                            // 배틀 제목, 존버 금액
+                            // 배틀 제목, 남은 예산
                             Column(
                               mainAxisAlignment: MainAxisAlignment.center,
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text(sample[1], style: CTextStyles.Headline()),
+                                Text(
+                                  battle.name,
+                                  style: CTextStyles.Headline(),
+                                ),
                                 SizedBox(height: 10),
                                 Text(
-                                  '존버 금액 : ${sample[2]} 원',
+                                  '남은 예산 : ${battle.budgetLeft} 원',
                                   style: CTextStyles.Body3(
                                     color: CColors.gray40,
                                   ),
@@ -101,24 +74,13 @@ class BattleBox extends StatelessWidget {
                           ],
                         ),
 
-                        // 참여자 수, 댓글 수, 입장 버튼
+                        // 참여자 수, 입장 버튼
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            Row(
-                              children: [
-                                Row(
-                                  children: [
-                                    Text('${sample[3]}위/20명',
-                                        style: CTextStyles.Title1()),
-                                    SizedBox(width: 40),
-                                    Icon(Icons.chat_outlined,
-                                        color: CColors.white, size: 16),
-                                    SizedBox(width: 1),
-                                    Text(sample[3], style: CTextStyles.Body3()),
-                                  ],
-                                ),
-                              ],
+                            Text(
+                              '${battle.currentParticipantRank}위/${battle.battleParticipantCount}명',
+                              style: CTextStyles.Title1(),
                             ),
                             OutlinedButton(
                               style: OutlinedButton.styleFrom(

--- a/lib/widget/home/carousel_slider.dart
+++ b/lib/widget/home/carousel_slider.dart
@@ -1,34 +1,29 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:poorlex/Libs/Theme.dart';
-import 'package:poorlex/controller/battle.dart';
+import 'package:poorlex/schema/member_progress_battle_response/member_progress_battle_response.dart';
 
 import 'package:poorlex/widget/home/battle_box.dart';
 import 'package:poorlex/widget/home/empty_battle.dart';
 
 class MainCarouselSlider extends StatefulWidget {
-  const MainCarouselSlider({super.key});
+  final List<MemberProgressBattleResponse> battleListInProgress;
+
+  const MainCarouselSlider({
+    super.key,
+    required this.battleListInProgress,
+  });
 
   @override
   State<MainCarouselSlider> createState() => _MainCarouselSliderState();
 }
 
 class _MainCarouselSliderState extends State<MainCarouselSlider> {
-  BattleController battle = Get.find<BattleController>();
-
-  final List<List<String>> samples = [
-    ['7', '빚갚고 돈모으는 절약방', '21000', '13'],
-    ['4', '월급때까지 돈 모으는 방', '35000', '7'],
-    ['0']
-  ];
-
   int _currentIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    battle.getBattle();
   }
 
   @override
@@ -48,7 +43,9 @@ class _MainCarouselSliderState extends State<MainCarouselSlider> {
             horizontal: 23,
           ),
           child: Text(
-            '참여 중인 배틀 (${_currentIndex + 1}/${samples.length})',
+            _currentIndex == widget.battleListInProgress.length
+                ? '배틀 방 만들기'
+                : '참여 중인 배틀 (${_currentIndex + 1}/${widget.battleListInProgress.length})',
             style: CTextStyles.Body3(color: CColors.black),
           ),
         ),
@@ -67,21 +64,24 @@ class _MainCarouselSliderState extends State<MainCarouselSlider> {
                 });
               },
             ),
-            itemCount: samples.length,
+            itemCount: widget.battleListInProgress.length + 1,
             itemBuilder: (BuildContext context, int index, int realIndex) {
-              final sample = samples[index];
-              return Container(
-                width: itemWidth,
-                child: Wrap(
-                  children: [
-                    if (sample[0] != '0') ...[
-                      BattleBox(sample: sample)
-                    ] else ...[
-                      EmptyBattle()
-                    ]
-                  ],
-                ),
-              );
+              if (index == widget.battleListInProgress.length) {
+                // 마지막 인덱스인 경우
+                return Container(
+                  width: itemWidth,
+                  child: EmptyBattle(),
+                );
+              } else {
+                // 일반 샘플 인덱스인 경우
+                final battle = widget.battleListInProgress[index];
+                return Container(
+                  width: itemWidth,
+                  child: Wrap(
+                    children: [BattleBox(battle: battle)],
+                  ),
+                );
+              }
             },
           ),
         ),

--- a/lib/widget/home/empty_battle.dart
+++ b/lib/widget/home/empty_battle.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:poorlex/libs/theme.dart';
 
-import 'package:poorlex/Libs/Theme.dart';
+import 'package:poorlex/screen/battle/battle_create.dart';
 
 class EmptyBattle extends StatelessWidget {
   const EmptyBattle({super.key});
@@ -11,46 +13,45 @@ class EmptyBattle extends StatelessWidget {
       builder: (context, constraints) {
         final double secondContainerWidth = constraints.maxWidth - 6;
 
-        return Stack(
-          alignment: Alignment.center,
-          children: [
-            Container(
-              decoration: BoxDecoration(color: CColors.black),
-              width: secondContainerWidth + 6,
-              height: 144,
-            ),
-            Container(
-              width: secondContainerWidth,
-              height: 150,
-              decoration: BoxDecoration(color: CColors.black),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  OutlinedButton(
-                    child: SizedBox(
+        return GestureDetector(
+          onTap: () {
+            /// [TODO] 예산 미설정 시 예산 설정 페이지로 라우팅
+            // 배틀 페이지로 이동
+            Get.to(() => BattleCreate());
+          },
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Container(
+                decoration: BoxDecoration(color: CColors.blackOpa80),
+                width: secondContainerWidth + 6,
+                height: 144,
+              ),
+              Container(
+                width: secondContainerWidth,
+                height: 150,
+                decoration: BoxDecoration(color: CColors.blackOpa80),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 36),
+                    SizedBox(
                       width: 34,
                       height: 34,
                       child: Image.asset('assets/main_page/empty_battle.png'),
                     ),
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(width: 0),
-                    ),
-                    onPressed: () {},
-                  ),
-                  OutlinedButton(
-                    child: Text(
+                    SizedBox(height: 12),
+                    Text(
                       '배틀 방 만들기',
-                      style: CTextStyles.Headline(color: CColors.gray70),
-                    ),
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(width: 0),
-                    ),
-                    onPressed: () {},
-                  )
-                ],
+                      style: CTextStyles.Title3(
+                        color: CColors.gray70,
+                      ),
+                    )
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         );
       },
     );

--- a/lib/widget/home/home_nav_bar.dart
+++ b/lib/widget/home/home_nav_bar.dart
@@ -5,9 +5,10 @@ import 'package:poorlex/libs/number_format.dart';
 import 'package:poorlex/libs/theme.dart';
 import 'package:poorlex/schema/weekly_budget_response/weekly_budget_response.dart';
 
-import 'package:poorlex/screen/budget/budget_page.dart';
 import 'package:poorlex/widget/common/buttons.dart';
 
+/// [TODO] 레벨, 프로그레스바, 포인트, 지출, 남은 날짜
+/// 유저 정보 반영하기
 class NavBar extends StatefulWidget implements PreferredSizeWidget {
   final WeeklyBudgetResponse budget;
 
@@ -70,7 +71,9 @@ class _NavBarState extends State<NavBar> {
                             children: [
                               // 예산 금액
                               Text(
-                                '$budgetMoney',
+                                widget.budget.exist == true
+                                    ? '$budgetMoney'
+                                    : '?',
                                 style: CTextStyles.Body2(),
                               ),
 
@@ -154,7 +157,7 @@ class _NavBarState extends State<NavBar> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                if (budgetMoney != '0') ...[
+                if (widget.budget.exist == true) ...[
                   Wrap(
                     spacing: 12,
                     alignment: WrapAlignment.center,


### PR DESCRIPTION
# 주간 예산 등록 기능 추가 & 홈 디자인 QA

## 추가사항
- 주간 예산 설정 기능 추가
- 진행중인 배틀 리스트 캐러셀 반영
- 배틀방 만들기 슬라이드 클릭 시 배틀 생성 페이지 이동

## 수정사항
- 하단 앱 바 패딩 값 수정 (!!!! 준호님 확인 필요)
- 홈 페이지 배경 더 자연스럽게 수정
- 알럿창 버튼 텍스트 반영 수정
- 배틀 페이지 접근 시 바텀 시트 -> 예산 설정 페이지 이동 수정
- 머니 바 금액 조정 및 디자인 수정