### PR TITLE
홈 페이지 네브바 유저 정보 연동 및 QA 수정

### DIFF
--- a/lib/bind/root_bind.dart
+++ b/lib/bind/root_bind.dart
@@ -3,12 +3,14 @@ import 'package:poorlex/controller/api.dart';
 import 'package:poorlex/controller/battle.dart';
 import 'package:poorlex/controller/image_picker.dart';
 import 'package:poorlex/controller/layout.dart';
+import 'package:poorlex/controller/point.dart';
 import 'package:poorlex/controller/user.dart';
 import 'package:poorlex/controller/weekly_budgets.dart';
 import 'package:poorlex/provider/battles_provider.dart';
 import 'package:poorlex/provider/expenditures_provider.dart';
 import 'package:poorlex/provider/login_provider.dart';
 import 'package:poorlex/provider/member_provider.dart';
+import 'package:poorlex/provider/point_provider.dart';
 import 'package:poorlex/provider/weekly_budgets_provider.dart';
 
 class RootBind extends Bindings {
@@ -19,6 +21,7 @@ class RootBind extends Bindings {
     Get.lazyPut(() => ExpendituresProvider());
     Get.lazyPut(() => BattlesProvider());
     Get.lazyPut(() => WeeklyBudgetsProvider());
+    Get.lazyPut(() => PointProvider());
 
     Get.put(ImagePickerController(), permanent: true);
     Get.put(LayoutController(), permanent: true);
@@ -42,6 +45,12 @@ class RootBind extends Bindings {
     Get.put(
       WeeklyBudgetsController(
         weeklyBudgetsProvider: Get.find(),
+      ),
+      permanent: true,
+    );
+    Get.put(
+      PointController(
+        pointProvider: Get.find(),
       ),
       permanent: true,
     );

--- a/lib/controller/point.dart
+++ b/lib/controller/point.dart
@@ -1,0 +1,43 @@
+import 'package:get/get.dart';
+import 'package:poorlex/provider/point_provider.dart';
+import 'package:poorlex/schema/point_level_bar_response/point_level_bar_response.dart';
+import 'package:poorlex/schema/point_response/point_response.dart';
+
+class PointController extends GetxController {
+  final PointProvider pointProvider;
+
+  PointController({
+    required this.pointProvider,
+  });
+
+  final Rx<PointResponse> point = PointResponse(
+    totalPoint: 0,
+    level: 0,
+  ).obs;
+
+  final Rx<PointLevelBarResponse> pointLevelBar = PointLevelBarResponse(
+    levelRange: 0,
+    currentPoint: 0,
+    recentPoint: 0,
+  ).obs;
+
+  // 회원 포인트, 레벨 조회
+  Future<void> getPoint() async {
+    try {
+      final response = await pointProvider.getPoint();
+      point(response);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  // 회원 레벨바 관련 포인트 조회
+  Future<void> getPointLevelBar() async {
+    try {
+      final response = await pointProvider.getPointLevelBar();
+      pointLevelBar(response);
+    } catch (e) {
+      print(e);
+    }
+  }
+}

--- a/lib/provider/point_provider.dart
+++ b/lib/provider/point_provider.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart';
+import 'package:poorlex/controller/user.dart';
+import 'package:poorlex/schema/point_level_bar_response/point_level_bar_response.dart';
+import 'package:poorlex/schema/point_response/point_response.dart';
+
+class PointProvider extends GetConnect {
+  @override
+  void onInit() {
+    // prefix "/point" 적용
+    httpClient.baseUrl = "${dotenv.get('SERVER_URL')}/point";
+
+    httpClient.addRequestModifier<Object?>((request) {
+      final user = Get.find<UserController>();
+      final token = user.userToken;
+      request.headers['Authorization'] = 'Bearer $token';
+      return request;
+    });
+
+    httpClient.addResponseModifier((request, response) async {
+      // bodyBytes가 Stream<List<int>> 타입이므로 이를 읽어와서 처리합니다.
+      final bodyBytes = await request.bodyBytes.toList();
+      if (bodyBytes.isNotEmpty) {
+        final bodyString = utf8.decode(bodyBytes.expand((x) => x).toList());
+        print('##### REQUEST BODY: $bodyString'); // 요청의 body를 로그로 출력
+      }
+      print(
+        '### REQUEST [method: ${request.method}]'
+        '\nURL: ${request.url}'
+        '\n${"Header : ${request.headers}"}'
+        '\n ### RESPONSE BODY: ${response.body}',
+      );
+      return response;
+    });
+  }
+
+  // 회원 포인트, 레벨 조회
+  Future<PointResponse?> getPoint() async {
+    final response = await get(
+      "",
+      decoder: (data) => PointResponse.fromJson(data),
+    );
+    return response.body;
+  }
+
+  // 회원 레벨바 관련 포인트 조회
+  Future<PointLevelBarResponse?> getPointLevelBar() async {
+    final response = await get(
+      "/level-bar",
+      decoder: (data) => PointLevelBarResponse.fromJson(data),
+    );
+    return response.body;
+  }
+}

--- a/lib/provider/weekly_budgets_provider.dart
+++ b/lib/provider/weekly_budgets_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:poorlex/controller/user.dart';
@@ -15,6 +17,22 @@ class WeeklyBudgetsProvider extends GetConnect {
       final token = user.userToken;
       request.headers['Authorization'] = 'Bearer $token';
       return request;
+    });
+
+    httpClient.addResponseModifier((request, response) async {
+      // bodyBytes가 Stream<List<int>> 타입이므로 이를 읽어와서 처리합니다.
+      final bodyBytes = await request.bodyBytes.toList();
+      if (bodyBytes.isNotEmpty) {
+        final bodyString = utf8.decode(bodyBytes.expand((x) => x).toList());
+        print('##### REQUEST BODY: $bodyString'); // 요청의 body를 로그로 출력
+      }
+      print(
+        '### REQUEST [method: ${request.method}]'
+        '\n### URL: ${request.url}'
+        '\n### Header : ${request.headers}'
+        '\n### RESPONSE BODY: ${response.body}',
+      );
+      return response;
     });
   }
 
@@ -42,7 +60,7 @@ class WeeklyBudgetsProvider extends GetConnect {
   }) async {
     try {
       final response = await post("", {'budget': budget});
-      print("주간 예산 생성 > $response");
+      print("주간 예산 생성 > ${response.statusCode}");
       return response.status == 201;
     } catch (e) {
       print(e);

--- a/lib/schema/point_level_bar_response/point_level_bar_response.dart
+++ b/lib/schema/point_level_bar_response/point_level_bar_response.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'point_level_bar_response.freezed.dart';
+part 'point_level_bar_response.g.dart';
+
+@freezed
+class PointLevelBarResponse with _$PointLevelBarResponse {
+  const factory PointLevelBarResponse({
+    required int levelRange,
+    required int currentPoint,
+    required int recentPoint,
+  }) = _PointLevelBarResponse;
+
+  factory PointLevelBarResponse.fromJson(Map<String, dynamic> json) =>
+      _$PointLevelBarResponseFromJson(json);
+}

--- a/lib/schema/point_level_bar_response/point_level_bar_response.freezed.dart
+++ b/lib/schema/point_level_bar_response/point_level_bar_response.freezed.dart
@@ -1,0 +1,198 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'point_level_bar_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PointLevelBarResponse _$PointLevelBarResponseFromJson(
+    Map<String, dynamic> json) {
+  return _PointLevelBarResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PointLevelBarResponse {
+  int get levelRange => throw _privateConstructorUsedError;
+  int get currentPoint => throw _privateConstructorUsedError;
+  int get recentPoint => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PointLevelBarResponseCopyWith<PointLevelBarResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PointLevelBarResponseCopyWith<$Res> {
+  factory $PointLevelBarResponseCopyWith(PointLevelBarResponse value,
+          $Res Function(PointLevelBarResponse) then) =
+      _$PointLevelBarResponseCopyWithImpl<$Res, PointLevelBarResponse>;
+  @useResult
+  $Res call({int levelRange, int currentPoint, int recentPoint});
+}
+
+/// @nodoc
+class _$PointLevelBarResponseCopyWithImpl<$Res,
+        $Val extends PointLevelBarResponse>
+    implements $PointLevelBarResponseCopyWith<$Res> {
+  _$PointLevelBarResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? levelRange = null,
+    Object? currentPoint = null,
+    Object? recentPoint = null,
+  }) {
+    return _then(_value.copyWith(
+      levelRange: null == levelRange
+          ? _value.levelRange
+          : levelRange // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentPoint: null == currentPoint
+          ? _value.currentPoint
+          : currentPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+      recentPoint: null == recentPoint
+          ? _value.recentPoint
+          : recentPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PointLevelBarResponseImplCopyWith<$Res>
+    implements $PointLevelBarResponseCopyWith<$Res> {
+  factory _$$PointLevelBarResponseImplCopyWith(
+          _$PointLevelBarResponseImpl value,
+          $Res Function(_$PointLevelBarResponseImpl) then) =
+      __$$PointLevelBarResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int levelRange, int currentPoint, int recentPoint});
+}
+
+/// @nodoc
+class __$$PointLevelBarResponseImplCopyWithImpl<$Res>
+    extends _$PointLevelBarResponseCopyWithImpl<$Res,
+        _$PointLevelBarResponseImpl>
+    implements _$$PointLevelBarResponseImplCopyWith<$Res> {
+  __$$PointLevelBarResponseImplCopyWithImpl(_$PointLevelBarResponseImpl _value,
+      $Res Function(_$PointLevelBarResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? levelRange = null,
+    Object? currentPoint = null,
+    Object? recentPoint = null,
+  }) {
+    return _then(_$PointLevelBarResponseImpl(
+      levelRange: null == levelRange
+          ? _value.levelRange
+          : levelRange // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentPoint: null == currentPoint
+          ? _value.currentPoint
+          : currentPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+      recentPoint: null == recentPoint
+          ? _value.recentPoint
+          : recentPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PointLevelBarResponseImpl implements _PointLevelBarResponse {
+  const _$PointLevelBarResponseImpl(
+      {required this.levelRange,
+      required this.currentPoint,
+      required this.recentPoint});
+
+  factory _$PointLevelBarResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PointLevelBarResponseImplFromJson(json);
+
+  @override
+  final int levelRange;
+  @override
+  final int currentPoint;
+  @override
+  final int recentPoint;
+
+  @override
+  String toString() {
+    return 'PointLevelBarResponse(levelRange: $levelRange, currentPoint: $currentPoint, recentPoint: $recentPoint)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PointLevelBarResponseImpl &&
+            (identical(other.levelRange, levelRange) ||
+                other.levelRange == levelRange) &&
+            (identical(other.currentPoint, currentPoint) ||
+                other.currentPoint == currentPoint) &&
+            (identical(other.recentPoint, recentPoint) ||
+                other.recentPoint == recentPoint));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, levelRange, currentPoint, recentPoint);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PointLevelBarResponseImplCopyWith<_$PointLevelBarResponseImpl>
+      get copyWith => __$$PointLevelBarResponseImplCopyWithImpl<
+          _$PointLevelBarResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PointLevelBarResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PointLevelBarResponse implements PointLevelBarResponse {
+  const factory _PointLevelBarResponse(
+      {required final int levelRange,
+      required final int currentPoint,
+      required final int recentPoint}) = _$PointLevelBarResponseImpl;
+
+  factory _PointLevelBarResponse.fromJson(Map<String, dynamic> json) =
+      _$PointLevelBarResponseImpl.fromJson;
+
+  @override
+  int get levelRange;
+  @override
+  int get currentPoint;
+  @override
+  int get recentPoint;
+  @override
+  @JsonKey(ignore: true)
+  _$$PointLevelBarResponseImplCopyWith<_$PointLevelBarResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/schema/point_level_bar_response/point_level_bar_response.g.dart
+++ b/lib/schema/point_level_bar_response/point_level_bar_response.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'point_level_bar_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PointLevelBarResponseImpl _$$PointLevelBarResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PointLevelBarResponseImpl(
+      levelRange: (json['levelRange'] as num).toInt(),
+      currentPoint: (json['currentPoint'] as num).toInt(),
+      recentPoint: (json['recentPoint'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$PointLevelBarResponseImplToJson(
+        _$PointLevelBarResponseImpl instance) =>
+    <String, dynamic>{
+      'levelRange': instance.levelRange,
+      'currentPoint': instance.currentPoint,
+      'recentPoint': instance.recentPoint,
+    };

--- a/lib/schema/point_response/point_response.dart
+++ b/lib/schema/point_response/point_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'point_response.freezed.dart';
+part 'point_response.g.dart';
+
+@freezed
+class PointResponse with _$PointResponse {
+  const factory PointResponse({
+    required int totalPoint,
+    required int level,
+  }) = _PointResponse;
+
+  factory PointResponse.fromJson(Map<String, dynamic> json) =>
+      _$PointResponseFromJson(json);
+}

--- a/lib/schema/point_response/point_response.freezed.dart
+++ b/lib/schema/point_response/point_response.freezed.dart
@@ -1,0 +1,170 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'point_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PointResponse _$PointResponseFromJson(Map<String, dynamic> json) {
+  return _PointResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PointResponse {
+  int get totalPoint => throw _privateConstructorUsedError;
+  int get level => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PointResponseCopyWith<PointResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PointResponseCopyWith<$Res> {
+  factory $PointResponseCopyWith(
+          PointResponse value, $Res Function(PointResponse) then) =
+      _$PointResponseCopyWithImpl<$Res, PointResponse>;
+  @useResult
+  $Res call({int totalPoint, int level});
+}
+
+/// @nodoc
+class _$PointResponseCopyWithImpl<$Res, $Val extends PointResponse>
+    implements $PointResponseCopyWith<$Res> {
+  _$PointResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalPoint = null,
+    Object? level = null,
+  }) {
+    return _then(_value.copyWith(
+      totalPoint: null == totalPoint
+          ? _value.totalPoint
+          : totalPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+      level: null == level
+          ? _value.level
+          : level // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PointResponseImplCopyWith<$Res>
+    implements $PointResponseCopyWith<$Res> {
+  factory _$$PointResponseImplCopyWith(
+          _$PointResponseImpl value, $Res Function(_$PointResponseImpl) then) =
+      __$$PointResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int totalPoint, int level});
+}
+
+/// @nodoc
+class __$$PointResponseImplCopyWithImpl<$Res>
+    extends _$PointResponseCopyWithImpl<$Res, _$PointResponseImpl>
+    implements _$$PointResponseImplCopyWith<$Res> {
+  __$$PointResponseImplCopyWithImpl(
+      _$PointResponseImpl _value, $Res Function(_$PointResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? totalPoint = null,
+    Object? level = null,
+  }) {
+    return _then(_$PointResponseImpl(
+      totalPoint: null == totalPoint
+          ? _value.totalPoint
+          : totalPoint // ignore: cast_nullable_to_non_nullable
+              as int,
+      level: null == level
+          ? _value.level
+          : level // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PointResponseImpl implements _PointResponse {
+  const _$PointResponseImpl({required this.totalPoint, required this.level});
+
+  factory _$PointResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PointResponseImplFromJson(json);
+
+  @override
+  final int totalPoint;
+  @override
+  final int level;
+
+  @override
+  String toString() {
+    return 'PointResponse(totalPoint: $totalPoint, level: $level)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PointResponseImpl &&
+            (identical(other.totalPoint, totalPoint) ||
+                other.totalPoint == totalPoint) &&
+            (identical(other.level, level) || other.level == level));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, totalPoint, level);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PointResponseImplCopyWith<_$PointResponseImpl> get copyWith =>
+      __$$PointResponseImplCopyWithImpl<_$PointResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PointResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PointResponse implements PointResponse {
+  const factory _PointResponse(
+      {required final int totalPoint,
+      required final int level}) = _$PointResponseImpl;
+
+  factory _PointResponse.fromJson(Map<String, dynamic> json) =
+      _$PointResponseImpl.fromJson;
+
+  @override
+  int get totalPoint;
+  @override
+  int get level;
+  @override
+  @JsonKey(ignore: true)
+  _$$PointResponseImplCopyWith<_$PointResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/schema/point_response/point_response.g.dart
+++ b/lib/schema/point_response/point_response.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'point_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PointResponseImpl _$$PointResponseImplFromJson(Map<String, dynamic> json) =>
+    _$PointResponseImpl(
+      totalPoint: (json['totalPoint'] as num).toInt(),
+      level: (json['level'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$PointResponseImplToJson(_$PointResponseImpl instance) =>
+    <String, dynamic>{
+      'totalPoint': instance.totalPoint,
+      'level': instance.level,
+    };

--- a/lib/screen/home/home.dart
+++ b/lib/screen/home/home.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:poorlex/controller/audio_controller.dart';
 import 'package:poorlex/controller/battle.dart';
+import 'package:poorlex/controller/point.dart';
 // import 'package:poorlex/controller/firbase_controller.dart';
 import 'package:poorlex/controller/weekly_budgets.dart';
 import 'package:poorlex/libs/theme.dart';
@@ -38,7 +40,11 @@ class _MainState extends State<Main> {
   // }
 
   late final _budget = Get.find<WeeklyBudgetsController>();
+  late final _point = Get.find<PointController>();
   BattleController battle = Get.find<BattleController>();
+
+  // 예산 설정 안내 문구 상태 변수
+  bool _showBudgetHint = true;
 
   @override
   void initState() {
@@ -48,6 +54,8 @@ class _MainState extends State<Main> {
     // FirebaseController().showFcmToken(context: context);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _budget.getWeeklyBudgets();
+      _point.point();
+      _point.pointLevelBar();
     });
 
     battle.getBattleInProgress();
@@ -71,12 +79,20 @@ class _MainState extends State<Main> {
     return Obx(
       () {
         final budget = _budget.weeklyBudget.value;
+        final point = _point.point.value;
+        final pointLevelBar = _point.pointLevelBar.value;
 
         print('#Home# budget: ${budget}');
+        print('#Home# point: ${point}');
+        print('#Home# pointLevelBar: ${pointLevelBar}');
 
         return Scaffold(
           // 네비게이션 바
-          appBar: NavBar(budget: budget),
+          appBar: NavBar(
+            budget: budget,
+            point: point,
+            pointLevelBar: pointLevelBar,
+          ),
           body: Container(
             width: deviceWidth,
             height: deviceHeight,
@@ -142,7 +158,7 @@ class _MainState extends State<Main> {
                 ),
 
                 // 예산 설정 안내 문구
-                if (budget.exist == false)
+                if (budget.exist == false && _showBudgetHint)
                   Positioned(
                     top: 4,
                     left: 15,
@@ -169,12 +185,40 @@ class _MainState extends State<Main> {
 
                           // 예산 설정 안내 문구 박스
                           Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
                             alignment: Alignment.center,
-                            width: 242,
+                            // width: 242,
                             height: 30,
-                            child: Text(
-                              "예산을 설정해야 배틀이 가능해요!",
-                              style: CTextStyles.Body3(),
+                            child: Row(
+                              children: [
+                                Text(
+                                  "예산을 설정해야 배틀이 가능해요!",
+                                  style: CTextStyles.Body3(),
+                                ),
+                                SizedBox(
+                                  width: 30,
+                                  height: 30,
+                                  child: IconButton(
+                                    padding: EdgeInsets.only(left: 10),
+                                    constraints: BoxConstraints(),
+                                    onPressed: () {
+                                      // 예산 설정 알림 상태 업데이트
+                                      setState(() {
+                                        _showBudgetHint = false;
+                                      });
+
+                                      AudioController().play(
+                                        audioType: AudioType.complete,
+                                      );
+                                    },
+                                    icon: Icon(Icons.close),
+                                    iconSize: 20,
+                                    color: CColors.white,
+                                  ),
+                                ),
+                              ],
                             ),
                             decoration: BoxDecoration(
                               color: CColors.purple,

--- a/lib/widget/home/carousel_slider.dart
+++ b/lib/widget/home/carousel_slider.dart
@@ -63,8 +63,11 @@ class _MainCarouselSliderState extends State<MainCarouselSlider> {
                   _currentIndex = index;
                 });
               },
+              enableInfiniteScroll: widget.battleListInProgress.isNotEmpty,
             ),
-            itemCount: widget.battleListInProgress.length + 1,
+            itemCount: widget.battleListInProgress.isEmpty
+                ? 1
+                : widget.battleListInProgress.length + 1,
             itemBuilder: (BuildContext context, int index, int realIndex) {
               if (index == widget.battleListInProgress.length) {
                 // 마지막 인덱스인 경우

--- a/lib/widget/home/home_nav_bar.dart
+++ b/lib/widget/home/home_nav_bar.dart
@@ -3,6 +3,8 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:poorlex/libs/number_format.dart';
 import 'package:poorlex/libs/theme.dart';
+import 'package:poorlex/schema/point_level_bar_response/point_level_bar_response.dart';
+import 'package:poorlex/schema/point_response/point_response.dart';
 import 'package:poorlex/schema/weekly_budget_response/weekly_budget_response.dart';
 
 import 'package:poorlex/widget/common/buttons.dart';
@@ -11,10 +13,14 @@ import 'package:poorlex/widget/common/buttons.dart';
 /// 유저 정보 반영하기
 class NavBar extends StatefulWidget implements PreferredSizeWidget {
   final WeeklyBudgetResponse budget;
+  final PointResponse point;
+  final PointLevelBarResponse pointLevelBar;
 
   const NavBar({
     super.key,
     required this.budget,
+    required this.point,
+    required this.pointLevelBar,
   });
 
   @override
@@ -30,8 +36,6 @@ class _NavBarState extends State<NavBar> {
   late String budgetWithWon;
   late String budgetMoney;
 
-  String level = '4';
-
   @override
   void initState() {
     super.initState();
@@ -42,6 +46,30 @@ class _NavBarState extends State<NavBar> {
 
     print("### budgetMoney: $budgetMoney");
     print("### budgetWithWon: $budgetWithWon");
+  }
+
+  String getRemainingDaysText() {
+    DateTime now = DateTime.now();
+    int weekday = now.weekday;
+
+    switch (weekday) {
+      case 1:
+        return 'D-6'; // 월요일
+      case 2:
+        return 'D-5'; // 화요일
+      case 3:
+        return 'D-4'; // 수요일
+      case 4:
+        return 'D-3'; // 목요일
+      case 5:
+        return 'D-2'; // 금요일
+      case 6:
+        return 'D-1'; // 토요일
+      case 7:
+        return 'D-day'; // 일요일
+      default:
+        return 'D-?';
+    }
   }
 
   @override
@@ -100,7 +128,7 @@ class _NavBarState extends State<NavBar> {
                             horizontal: 6,
                           ),
                           child: Text(
-                            'D-7',
+                            getRemainingDaysText(),
                             style: CTextStyles.Body3(),
                           ),
                         ),
@@ -119,7 +147,7 @@ class _NavBarState extends State<NavBar> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                'LV.$level',
+                'LV.${widget.point.level}',
                 style: CTextStyles.Body2(color: CColors.yellow),
               ),
               Container(
@@ -129,12 +157,19 @@ class _NavBarState extends State<NavBar> {
                   children: [
                     Container(
                       width: 240 * 0.04,
+                      // width: 240 *
+                      //     widget.pointLevelBar.currentPoint /
+                      //     widget.pointLevelBar.levelRange,
                       child: Container(
                         color: CColors.yellow,
                       ),
                     ),
                     Container(
                       width: 240 * 0.96,
+                      // width: 240 *
+                      //     (widget.pointLevelBar.levelRange -
+                      //         widget.pointLevelBar.currentPoint) /
+                      //     widget.pointLevelBar.levelRange,
                       child: Container(
                         color: CColors.gray20,
                       ),
@@ -143,7 +178,7 @@ class _NavBarState extends State<NavBar> {
                 ),
               ),
               Text(
-                '+256 P',
+                '+${widget.point.totalPoint} P',
                 style: CTextStyles.Body2(color: CColors.yellow),
               ),
             ],


### PR DESCRIPTION
# 홈 페이지 네브바 유저 정보 연동 및 QA 수정

## 추가사항
- 홈 네브바 유저 정보 반영
  - 포인트 관련 API 연동
  - [❗️CHECK] 조회 시 현재 level, point, ... 모든 값 0으로 조회됨
- 예산 등록 알림 팝업 닫기 버튼 추가
- 디데이 반영

## 수정사항
- 참여중인 배틀 방이 없을 경우 무한 슬라이드 미적용